### PR TITLE
Driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://travis-ci.org/cloudcomputinghust/CAL.svg?branch=driver
+.. image:: https://travis-ci.org/cloudcomputinghust/CAL.svg?branch=master
     :target: https://travis-ci.org/cloudcomputinghust/CAL
     
 .. image:: https://coveralls.io/repos/github/cloudcomputinghust/CAL/badge.svg?branch=master

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://travis-ci.org/cloudcomputinghust/CAL.svg?branch=master
+.. image:: https://travis-ci.org/cloudcomputinghust/CAL.svg?branch=driver
     :target: https://travis-ci.org/cloudcomputinghust/CAL
     
 .. image:: https://coveralls.io/repos/github/cloudcomputinghust/CAL/badge.svg?branch=master

--- a/calplus/conf/opts.py
+++ b/calplus/conf/opts.py
@@ -1,0 +1,79 @@
+# Copyright 2015 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+This is the single point of entry to generate the sample configuration
+file for Nova. It collects all the necessary info from the other modules
+in this package. It is assumed that:
+
+* every other module in this package has a 'list_opts' function which
+  return a dict where
+  * the keys are strings which are the group names
+  * the value of each key is a list of config options for that group
+* the nova.conf package doesn't have further packages with config options
+* this module is only used in the context of sample file generation
+"""
+
+import collections
+import importlib
+import os
+import pkgutil
+
+LIST_OPTS_FUNC_NAME = "list_opts"
+
+
+def _tupleize(dct):
+    """Take the dict of options and convert to the 2-tuple format."""
+    return [(key, val) for key, val in dct.items()]
+
+
+def list_opts():
+    opts = collections.defaultdict(list)
+    module_names = _list_module_names()
+    imported_modules = _import_modules(module_names)
+    _append_config_options(imported_modules, opts)
+    return _tupleize(opts)
+
+
+def _list_module_names():
+    module_names = []
+    package_path = os.path.dirname(os.path.abspath(__file__))
+    for _, modname, ispkg in pkgutil.iter_modules(path=[package_path]):
+        if modname == "opts" or ispkg:
+            continue
+        else:
+            module_names.append(modname)
+    return module_names
+
+
+def _import_modules(module_names):
+    imported_modules = []
+    for modname in module_names:
+        mod = importlib.import_module("calplus.conf." + modname)
+        if not hasattr(mod, LIST_OPTS_FUNC_NAME):
+            msg = "The module 'calplus.conf.%s' should have a '%s' "\
+                  "function which returns the config options." % \
+                  (modname, LIST_OPTS_FUNC_NAME)
+            raise Exception(msg)
+        else:
+            imported_modules.append(mod)
+    return imported_modules
+
+
+def _append_config_options(imported_modules, config_options):
+    for mod in imported_modules:
+        configs = mod.list_opts()
+        for key, val in configs.items():
+            config_options[key].extend(val)

--- a/calplus/conf/providers.py
+++ b/calplus/conf/providers.py
@@ -35,6 +35,7 @@ os1_auth_opts = {
     'os_identity_api_version': '3',
     'os_image_api_version': '2',
     'tenant_id': 'fake_tenant_id',
+    'os_novaclient_version': '2.1',
     'limit': {
         "subnet": 10,
         "network": 10,

--- a/calplus/conf/providers.py
+++ b/calplus/conf/providers.py
@@ -85,7 +85,18 @@ aws1_auth_opts = {
     'aws_access_key_id': 'c543fa29eeaf4894a1078ec0860baefd',
     'aws_secret_access_key': 'd2246a2235ca40ffa7fbf817ae1108ba',
     'region_name': 'RegionOne',
-    'endpoint_url': 'http://192.168.122.75:8788'
+    'endpoint_url': 'http://192.168.122.75:8788',
+    'limit': {
+        "subnet": 10,
+        "vpc": 5,
+        "floatingip": 50,
+        "subnetpool": -1,
+        "security_group_rule": 100,
+        "security_group": 10,
+        "router": 10,
+        "rbac_policy": -1,
+        "port": 50
+    }
 }
 
 

--- a/calplus/tests/unit/v1/compute/drivers/test_base_driver.py
+++ b/calplus/tests/unit/v1/compute/drivers/test_base_driver.py
@@ -1,0 +1,114 @@
+""" OpenstackDriver for Network
+    based on NetworkDriver
+"""
+
+
+from calplus.tests import base
+from calplus.v1.compute.drivers.base import BaseDriver
+
+
+class FakeDriver(BaseDriver):
+    """docstring for FakeDriver
+        This class implemented all of BaseDriver functions
+    """
+    def __init__(self):
+        super(FakeDriver, self).__init__()
+
+    def create(self, image_id, flavor_id,
+               network_id, name=None, number=1, **kargs):
+        return 'fake_result'
+
+    def show(self, instance_id):
+        return 'fake_result'
+
+    def list(self, **search_opts):
+        return 'fake_result'
+
+    def delete(self, instance_id):
+        return 'fake_result'
+
+    def shutdown(self, instance_id):
+        return 'fake_result'
+
+    def start(self, instance_id):
+        return 'fake_result'
+
+    def reboot(self, instance_id):
+        return 'fake_result'
+
+    def resize(self, instance_id, configuration):
+        return 'fake_result'
+
+    def add_sg(self, instance_id, new_sg):
+        """Add a security group"""
+        return 'fake_result'
+
+    def delete_sg(self, instance_id, new_sg):
+        """Delete a security group"""
+        return 'fake_result'
+
+    def list_sg(self, instance_id):
+        """List all security group"""
+        return 'fake_result'
+
+    def add_nic(self, instance_id, new_sg):
+        """Add a Network Interface Controller"""
+        return 'fake_result'
+
+    def delete_nic(self, instance_id, new_sg):
+        """Delete a Network Interface Controller"""
+        return 'fake_result'
+
+    def list_nic(self, instance_id):
+        """List all Network Interface Controller"""
+        return 'fake_result'
+
+    def add_private_ip(self, instance_id, new_sg):
+        """Add private IP"""
+        return 'fake_result'
+
+    def delete_private_ip(self, instance_id, new_sg):
+        """Delete private IP"""
+        return 'fake_result'
+
+    def add_public_ip(self, instance_id, new_sg):
+        """Add a external IP"""
+        return 'fake_result'
+
+    def delete_public_ip(self, instance_id, new_sg):
+        """Delete a external IP"""
+        return 'fake_result'
+
+    def list_ip(self, instance_id, new_sg):
+        """Add all IPs"""
+        return 'fake_result'
+
+
+class FakeDriverError(BaseDriver):
+    """docstring for FakeDriverError
+        This class didn't implement some functions
+    """
+    def __init__(self):
+        super(FakeDriverError, self).__init__()
+
+    def create(self, image_id, flavor_id,
+               network_id, name=None, number=1, **kargs):
+        return 'fake_result'
+
+    def show(self, instance_id):
+        return 'fake_result'
+
+
+class ComputeDriverTest(base.TestCase):
+
+    """Testing class for BaseDriver"""
+
+    def setUp(self):
+        super(ComputeDriverTest, self).setUp()
+
+    def test_create_base_driver_object(self):
+        fake_driver = FakeDriver()
+        self.assertIsInstance(fake_driver, FakeDriver)
+
+    def test_create_base_driver_object_unable_to_create(self):
+        self.assertRaises(TypeError, FakeDriverError)

--- a/calplus/tests/unit/v1/compute/drivers/test_base_driver.py
+++ b/calplus/tests/unit/v1/compute/drivers/test_base_driver.py
@@ -1,5 +1,4 @@
-""" OpenstackDriver for Network
-    based on NetworkDriver
+""" Some test for BaseDriver
 """
 
 

--- a/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
+++ b/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
@@ -1,0 +1,102 @@
+""" OpenstackDriver for Compute
+    based on BaseDriver fror Compute Resource
+"""
+
+
+import mock
+from keystoneauth1.exceptions.base import ClientException
+
+from calplus.tests import base
+from calplus.v1.compute.drivers.openstack import OpenstackDriver
+
+fake_config_driver = {
+    'os_auth_url': 'http://controller:5000/v2_0',
+    'os_username': 'test',
+    'os_password': 'veryhard',
+    'os_project_name': 'demo',
+    'os_endpoint_url': 'http://controller:9696',
+    'os_driver_name': 'default',
+    'os_project_domain_name': 'default',
+    'os_user_domain_name': 'default',
+    'tenant_id': 'fake_tenant_id',
+    'limit': {
+        "subnet": 10,
+        "network": 10,
+        "floatingip": 50,
+        "subnetpool": -1,
+        "security_group_rule": 100,
+        "security_group": 10,
+        "router": 10,
+        "rbac_policy": -1,
+        "port": 50
+    }
+}
+
+
+class OpenstackDriverTest(base.TestCase):
+
+    """docstring for OpenstackDriverTest"""
+
+    def setUp(self):
+        super(OpenstackDriverTest, self).setUp()
+        self.fake_driver = OpenstackDriver(fake_config_driver)
+
+    def test_create_successfully(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'create',
+            mock.Mock(return_value=mock.Mock))
+        #NOTE: in fact: mock.Mock is novaclient.v2.servers.Server
+
+        self.fake_driver.create(
+            'fake_image_id',
+            'fake_flavor_id',
+            'fake_net_id',
+            'fake_name'
+        )
+
+        self.fake_driver.client.servers.create.\
+            assert_called_once_with(
+                name='fake_name',
+                image='fake_image_id',
+                flavor='fake_flavor_id',
+                nics=[{'net-id': 'fake_net_id'}]
+            )
+
+    def test_create_without_instance_name(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'create',
+            mock.Mock(return_value=mock.Mock))
+        # NOTE: in fact: mock.Mock is novaclient.v2.servers.Server
+
+        self.fake_driver.create(
+            'fake_image_id',
+            'fake_flavor_id',
+            'fake_net_id'
+        )
+
+        self.fake_driver.client.servers.create. \
+            assert_called_once_with(
+                name=mock.ANY,
+                image='fake_image_id',
+                flavor='fake_flavor_id',
+                nics=[{'net-id': 'fake_net_id'}]
+            )
+
+    def test_create_unable_to_create_instance(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'create',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException, self.fake_driver.create,
+                'fake_image_id',
+                'fake_flavor_id',
+                'fake_net_id',
+                'fake_name')
+
+        self.fake_driver.client.servers.create. \
+            assert_called_once_with(
+                name='fake_name',
+                image='fake_image_id',
+                flavor='fake_flavor_id',
+                nics=[{'net-id': 'fake_net_id'}]
+            )

--- a/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
+++ b/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
@@ -4,6 +4,7 @@
 
 
 import mock
+
 from keystoneauth1.exceptions.base import ClientException
 
 from calplus.tests import base

--- a/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
+++ b/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
@@ -1,5 +1,5 @@
 """ OpenstackDriver for Compute
-    based on BaseDriver fror Compute Resource
+    based on BaseDriver for Compute Resource
 """
 
 

--- a/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
+++ b/calplus/tests/unit/v1/compute/drivers/test_openstack_driver.py
@@ -100,3 +100,131 @@ class OpenstackDriverTest(base.TestCase):
                 flavor='fake_flavor_id',
                 nics=[{'net-id': 'fake_net_id'}]
             )
+
+    def test_show_successfully(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'get',
+            mock.Mock(return_value=mock.Mock))
+        # NOTE: in fact: mock.Mock is novaclient.v2.servers.Server
+
+        self.fake_driver.show('fake_id')
+
+        self.fake_driver.client.servers.get. \
+            assert_called_once_with('fake_id')
+
+    def test_show_unable_to_show(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'get',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_driver.show, 'fake_id')
+
+        self.fake_driver.client.servers.get. \
+            assert_called_once_with('fake_id')
+
+    def test_list_successfully(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'list',
+            mock.Mock(return_value=[mock.Mock, mock.Mock]))
+        # NOTE: in fact: return_value is novaclient.base.ListWithMeta
+
+        self.fake_driver.list()
+
+        self.fake_driver.client.servers.list. \
+            assert_called_once_with()
+
+    def test_list_unable_to_list(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'list',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_driver.list)
+
+        self.fake_driver.client.servers.list. \
+            assert_called_once_with()
+
+    def test_delete_successfully(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'delete',
+            mock.Mock(return_value=True))
+
+        self.fake_driver.delete('fake_id')
+
+        self.fake_driver.client.servers.delete. \
+            assert_called_once_with('fake_id')
+
+    def test_delete_unable_to_delete(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'delete',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_driver.delete, 'fake_id')
+
+        self.fake_driver.client.servers.delete. \
+            assert_called_once_with('fake_id')
+
+    def test_shutdown_successfully(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'stop',
+            mock.Mock(return_value=True))
+
+        self.fake_driver.shutdown('fake_id')
+
+        self.fake_driver.client.servers.stop. \
+            assert_called_once_with('fake_id')
+
+    def test_shutdown_unable_to_shutdown(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'stop',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_driver.shutdown, 'fake_id')
+
+        self.fake_driver.client.servers.stop. \
+            assert_called_once_with('fake_id')
+
+    def test_start_successfully(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'start',
+            mock.Mock(return_value=True))
+
+        self.fake_driver.start('fake_id')
+
+        self.fake_driver.client.servers.start. \
+            assert_called_once_with('fake_id')
+
+    def test_start_unable_to_start(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'start',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_driver.start, 'fake_id')
+
+        self.fake_driver.client.servers.start. \
+            assert_called_once_with('fake_id')
+
+    def test_reboot_successfully(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'reboot',
+            mock.Mock(return_value=True))
+
+        self.fake_driver.reboot('fake_id')
+
+        self.fake_driver.client.servers.reboot. \
+            assert_called_once_with('fake_id')
+
+    def test_reboot_unable_to_reboot(self):
+        self.mock_object(
+            self.fake_driver.client.servers, 'reboot',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_driver.reboot, 'fake_id')
+
+        self.fake_driver.client.servers.reboot. \
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -1,0 +1,58 @@
+import mock
+from keystoneauth1.exceptions.base import ClientException
+
+from calplus.tests import base
+from calplus.v1.compute import client
+
+
+fake_config_driver = {
+    'os_auth_url': 'http://controller:5000/v2_0',
+    'os_username': 'test',
+    'os_password': 'veryhard',
+    'os_project_name': 'demo',
+    'os_endpoint_url': 'http://controller:9696',
+    'os_driver_name': 'default',
+    'os_project_domain_name': 'default',
+    'os_user_domain_name': 'default',
+    'tenant_id': 'fake_tenant_id',
+    'limit': {
+        "vcpus": 10,
+        "instances": 10,
+        "ram": 5000
+    }
+}
+
+
+class ClientTest(base.TestCase):
+
+    """docstring for ClientTest"""
+
+    def setUp(self):
+        super(ClientTest, self).setUp()
+        self.fake_client = client.Client(
+            'OpenStack', fake_config_driver)
+
+    def test_create_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'create',
+            mock.Mock(return_value="return object"))
+
+        self.fake_client.create('1', '1',
+                                'net_id', 'random', 1)
+
+        self.fake_client.driver.create.\
+            assert_called_once_with('1', '1',
+                                    'net_id', 'random', 1)
+
+    def test_create_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'create',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.create, '1', '1',
+                          'net_id', 'random', 1)
+
+        self.fake_client.driver.create.\
+            assert_called_once_with('1', '1',
+                                    'net_id', 'random', 1)

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -119,3 +119,24 @@ class ClientTest(base.TestCase):
 
         self.fake_client.driver.delete.\
             assert_called_once_with('fake_id')
+
+    def test_shutdown_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'shutdown',
+            mock.Mock(return_value=True))
+
+        self.fake_client.shutdown('fake_id')
+
+        self.fake_client.driver.shutdown.\
+            assert_called_once_with('fake_id')
+
+    def test_shutdown_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'shutdown',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.shutdown, 'fake_id')
+
+        self.fake_client.driver.shutdown.\
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -98,3 +98,24 @@ class ClientTest(base.TestCase):
 
         self.fake_client.driver.list.\
             assert_called_once_with()
+
+    def test_delete_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'delete',
+            mock.Mock(return_value=True))
+
+        self.fake_client.delete('fake_id')
+
+        self.fake_client.driver.delete.\
+            assert_called_once_with('fake_id')
+
+    def test_delete_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'delete',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.delete, 'fake_id')
+
+        self.fake_client.driver.delete.\
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -182,3 +182,28 @@ class ClientTest(base.TestCase):
 
         self.fake_client.driver.reboot.\
             assert_called_once_with('fake_id')
+
+    def test_resize_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'resize',
+            mock.Mock(return_value=True))
+
+        self.fake_client.resize('fake_id',
+                                'fake_configuration')
+
+        self.fake_client.driver.resize.\
+            assert_called_once_with('fake_id',
+                                    'fake_configuration')
+
+    def test_resize_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'resize',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.resize, 'fake_id',
+                          'fake_configuration')
+
+        self.fake_client.driver.resize.\
+            assert_called_once_with('fake_id',
+                                    'fake_configuration')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -77,3 +77,24 @@ class ClientTest(base.TestCase):
 
         self.fake_client.driver.show.\
             assert_called_once_with('fake_id')
+
+    def test_list_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'list',
+            mock.Mock(return_value="list server objects"))
+
+        self.fake_client.list()
+
+        self.fake_client.driver.list.\
+            assert_called_once_with()
+
+    def test_list_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'list',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.list)
+
+        self.fake_client.driver.list.\
+            assert_called_once_with()

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -1,4 +1,5 @@
 import mock
+
 from keystoneauth1.exceptions.base import ClientException
 
 from calplus.tests import base

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -161,3 +161,24 @@ class ClientTest(base.TestCase):
 
         self.fake_client.driver.start.\
             assert_called_once_with('fake_id')
+
+    def test_reboot_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'reboot',
+            mock.Mock(return_value=True))
+
+        self.fake_client.reboot('fake_id')
+
+        self.fake_client.driver.reboot.\
+            assert_called_once_with('fake_id')
+
+    def test_reboot_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'reboot',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.reboot, 'fake_id')
+
+        self.fake_client.driver.reboot.\
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -257,3 +257,24 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.delete_nic.\
             assert_called_once_with('fake_id',
                                     'fake_port_id')
+
+    def test_list_nic_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'list_nic',
+            mock.Mock(return_value=True))
+
+        self.fake_client.list_nic('fake_id')
+
+        self.fake_client.driver.list_nic.\
+            assert_called_once_with('fake_id')
+
+    def test_list_nic_unable_to_list(self):
+        self.mock_object(
+            self.fake_client.driver, 'list_nic',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.list_nic, 'fake_id')
+
+        self.fake_client.driver.list_nic.\
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -56,3 +56,24 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.create.\
             assert_called_once_with('1', '1',
                                     'net_id', 'random', 1)
+
+    def test_show_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'show',
+            mock.Mock(return_value="return object"))
+
+        self.fake_client.show('fake_id')
+
+        self.fake_client.driver.show.\
+            assert_called_once_with('fake_id')
+
+    def test_show_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'show',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.show, 'fake_id')
+
+        self.fake_client.driver.show.\
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -207,3 +207,28 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.resize.\
             assert_called_once_with('fake_id',
                                     'fake_configuration')
+
+    def test_add_nic_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'add_nic',
+            mock.Mock(return_value=True))
+
+        self.fake_client.add_nic('fake_id',
+                                'fake_net_id')
+
+        self.fake_client.driver.add_nic.\
+            assert_called_once_with('fake_id',
+                                    'fake_net_id')
+
+    def test_add_nic_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'add_nic',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.add_nic, 'fake_id',
+                          'fake_net_id')
+
+        self.fake_client.driver.add_nic.\
+            assert_called_once_with('fake_id',
+                                    'fake_net_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -67,7 +67,7 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.show.\
             assert_called_once_with('fake_id')
 
-    def test_show_unable_to_create(self):
+    def test_show_unable_to_show(self):
         self.mock_object(
             self.fake_client.driver, 'show',
             mock.Mock(side_effect=ClientException))
@@ -88,7 +88,7 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.list.\
             assert_called_once_with()
 
-    def test_list_unable_to_create(self):
+    def test_list_unable_to_list(self):
         self.mock_object(
             self.fake_client.driver, 'list',
             mock.Mock(side_effect=ClientException))
@@ -109,7 +109,7 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.delete.\
             assert_called_once_with('fake_id')
 
-    def test_delete_unable_to_create(self):
+    def test_delete_unable_to_delete(self):
         self.mock_object(
             self.fake_client.driver, 'delete',
             mock.Mock(side_effect=ClientException))
@@ -130,7 +130,7 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.shutdown.\
             assert_called_once_with('fake_id')
 
-    def test_shutdown_unable_to_create(self):
+    def test_shutdown_unable_to_shutdown(self):
         self.mock_object(
             self.fake_client.driver, 'shutdown',
             mock.Mock(side_effect=ClientException))
@@ -151,7 +151,7 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.start.\
             assert_called_once_with('fake_id')
 
-    def test_start_unable_to_create(self):
+    def test_start_unable_to_start(self):
         self.mock_object(
             self.fake_client.driver, 'start',
             mock.Mock(side_effect=ClientException))
@@ -172,7 +172,7 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.reboot.\
             assert_called_once_with('fake_id')
 
-    def test_reboot_unable_to_create(self):
+    def test_reboot_unable_to_reboot(self):
         self.mock_object(
             self.fake_client.driver, 'reboot',
             mock.Mock(side_effect=ClientException))
@@ -195,7 +195,7 @@ class ClientTest(base.TestCase):
             assert_called_once_with('fake_id',
                                     'fake_configuration')
 
-    def test_resize_unable_to_create(self):
+    def test_resize_unable_to_resize(self):
         self.mock_object(
             self.fake_client.driver, 'resize',
             mock.Mock(side_effect=ClientException))
@@ -220,7 +220,7 @@ class ClientTest(base.TestCase):
             assert_called_once_with('fake_id',
                                     'fake_net_id')
 
-    def test_add_nic_unable_to_create(self):
+    def test_add_nic_unable_to_add(self):
         self.mock_object(
             self.fake_client.driver, 'add_nic',
             mock.Mock(side_effect=ClientException))
@@ -232,3 +232,28 @@ class ClientTest(base.TestCase):
         self.fake_client.driver.add_nic.\
             assert_called_once_with('fake_id',
                                     'fake_net_id')
+
+    def test_delete_nic_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'delete_nic',
+            mock.Mock(return_value=True))
+
+        self.fake_client.delete_nic('fake_id',
+                                'fake_port_id')
+
+        self.fake_client.driver.delete_nic.\
+            assert_called_once_with('fake_id',
+                                    'fake_port_id')
+
+    def test_delete_nic_unable_to_delete(self):
+        self.mock_object(
+            self.fake_client.driver, 'delete_nic',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.delete_nic, 'fake_id',
+                          'fake_port_id')
+
+        self.fake_client.driver.delete_nic.\
+            assert_called_once_with('fake_id',
+                                    'fake_port_id')

--- a/calplus/tests/unit/v1/compute/test_client.py
+++ b/calplus/tests/unit/v1/compute/test_client.py
@@ -140,3 +140,24 @@ class ClientTest(base.TestCase):
 
         self.fake_client.driver.shutdown.\
             assert_called_once_with('fake_id')
+
+    def test_start_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'start',
+            mock.Mock(return_value=True))
+
+        self.fake_client.start('fake_id')
+
+        self.fake_client.driver.start.\
+            assert_called_once_with('fake_id')
+
+    def test_start_unable_to_create(self):
+        self.mock_object(
+            self.fake_client.driver, 'start',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.start, 'fake_id')
+
+        self.fake_client.driver.start.\
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/network/drivers/test_amazon_driver.py
+++ b/calplus/tests/unit/v1/network/drivers/test_amazon_driver.py
@@ -1,5 +1,5 @@
 """ AmazonDriver for Network
-    based on BaseDriver
+    based on BaseDriver for Network Resource
 """
 
 

--- a/calplus/tests/unit/v1/network/drivers/test_base_driver.py
+++ b/calplus/tests/unit/v1/network/drivers/test_base_driver.py
@@ -35,10 +35,13 @@ class FakeDriver(BaseDriver):
     def disconnect_external_net(self, network_id):
         return 'fake_result'
 
+    def allocate_public_ip(self, network_id):
+        return 'fake_result'
+
 
 class FakeDriverError(BaseDriver):
     """docstring for FakeDriverError
-        This class didn't implement delete function
+        This class didn't implement some functions
     """
     def __init__(self):
         super(FakeDriverError, self).__init__()

--- a/calplus/tests/unit/v1/network/drivers/test_base_driver.py
+++ b/calplus/tests/unit/v1/network/drivers/test_base_driver.py
@@ -29,6 +29,12 @@ class FakeDriver(BaseDriver):
     def delete(self, network_id):
         return 'fake_result'
 
+    def connect_external_net(self, network_id):
+        return 'fake_result'
+
+    def disconnect_external_net(self, network_id):
+        return 'fake_result'
+
 
 class FakeDriverError(BaseDriver):
     """docstring for FakeDriverError
@@ -47,6 +53,12 @@ class FakeDriverError(BaseDriver):
         return 'fake_result'
 
     def update(self, network_id, network):
+        return 'fake_result'
+
+    def connect_external_net(self, network_id):
+        return 'fake_result'
+
+    def disconnect_external_net(self, network_id):
         return 'fake_result'
 
 

--- a/calplus/tests/unit/v1/network/drivers/test_base_driver.py
+++ b/calplus/tests/unit/v1/network/drivers/test_base_driver.py
@@ -38,6 +38,9 @@ class FakeDriver(BaseDriver):
     def allocate_public_ip(self, network_id):
         return 'fake_result'
 
+    def list_public_ip(self, **search_opts):
+        return 'fake_result'
+
 
 class FakeDriverError(BaseDriver):
     """docstring for FakeDriverError

--- a/calplus/tests/unit/v1/network/drivers/test_base_driver.py
+++ b/calplus/tests/unit/v1/network/drivers/test_base_driver.py
@@ -1,5 +1,4 @@
-""" OpenstackDriver for Network
-    based on NetworkDriver
+""" Some test for BaseDriver
 """
 
 

--- a/calplus/tests/unit/v1/network/drivers/test_openstack_driver.py
+++ b/calplus/tests/unit/v1/network/drivers/test_openstack_driver.py
@@ -1,5 +1,5 @@
 """ OpenstackDriver for Network
-    based on NetworkDriver
+    based on BaseDriver for Network Resource
 """
 
 

--- a/calplus/tests/unit/v1/network/test_client.py
+++ b/calplus/tests/unit/v1/network/test_client.py
@@ -185,3 +185,68 @@ class ClientTest(base.TestCase):
 
     def test_update_unable_to_update(self):
         pass
+
+    def test_connect_external_net_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'connect_external_net',
+            mock.Mock(return_value=None))
+        #TODO: alter None with exact return format
+
+        self.fake_client.connect_external_net('fake_id')
+
+        self.fake_client.driver.connect_external_net.\
+            assert_called_once_with('fake_id')
+
+    def test_connect_external_net_unable_to_connect(self):
+        self.mock_object(
+            self.fake_client.driver, 'connect_external_net',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.connect_external_net, 'fake_id')
+
+        self.fake_client.driver.connect_external_net.\
+            assert_called_once_with('fake_id')
+
+    def test_disconnect_external_net_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'disconnect_external_net',
+            mock.Mock(return_value=None))
+        #TODO: alter None with exact return format
+
+        self.fake_client.disconnect_external_net('fake_id')
+
+        self.fake_client.driver.disconnect_external_net.\
+            assert_called_once_with('fake_id')
+
+    def test_disconnect_external_net_unable_to_disconnect(self):
+        self.mock_object(
+            self.fake_client.driver, 'disconnect_external_net',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.disconnect_external_net, 'fake_id')
+
+        self.fake_client.driver.disconnect_external_net.\
+            assert_called_once_with('fake_id')
+
+    def test_allocate_public_ip_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'allocate_public_ip',
+            mock.Mock(return_value=True))
+
+        self.fake_client.allocate_public_ip('fake_id')
+
+        self.fake_client.driver.allocate_public_ip.\
+            assert_called_once_with('fake_id')
+
+    def test_allocate_public_ip_unable_to_allocate(self):
+        self.mock_object(
+            self.fake_client.driver, 'allocate_public_ip',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.allocate_public_ip, 'fake_id')
+
+        self.fake_client.driver.allocate_public_ip.\
+            assert_called_once_with('fake_id')

--- a/calplus/tests/unit/v1/network/test_client.py
+++ b/calplus/tests/unit/v1/network/test_client.py
@@ -235,10 +235,10 @@ class ClientTest(base.TestCase):
             self.fake_client.driver, 'allocate_public_ip',
             mock.Mock(return_value=True))
 
-        self.fake_client.allocate_public_ip('fake_id')
+        self.fake_client.allocate_public_ip()
 
         self.fake_client.driver.allocate_public_ip.\
-            assert_called_once_with('fake_id')
+            assert_called_once_with()
 
     def test_allocate_public_ip_unable_to_allocate(self):
         self.mock_object(
@@ -246,7 +246,7 @@ class ClientTest(base.TestCase):
             mock.Mock(side_effect=ClientException))
 
         self.assertRaises(ClientException,
-            self.fake_client.allocate_public_ip, 'fake_id')
+            self.fake_client.allocate_public_ip)
 
         self.fake_client.driver.allocate_public_ip.\
-            assert_called_once_with('fake_id')
+            assert_called_once_with()

--- a/calplus/tests/unit/v1/network/test_client.py
+++ b/calplus/tests/unit/v1/network/test_client.py
@@ -250,3 +250,24 @@ class ClientTest(base.TestCase):
 
         self.fake_client.driver.allocate_public_ip.\
             assert_called_once_with()
+
+    def test_list_public_ip_successfully(self):
+        self.mock_object(
+            self.fake_client.driver, 'list_public_ip',
+            mock.Mock(return_value='fake_list_ip'))
+
+        self.fake_client.list_public_ip()
+
+        self.fake_client.driver.list_public_ip.\
+            assert_called_once_with()
+
+    def test_list_public_ip_unable_to_list(self):
+        self.mock_object(
+            self.fake_client.driver, 'list_public_ip',
+            mock.Mock(side_effect=ClientException))
+
+        self.assertRaises(ClientException,
+            self.fake_client.list_public_ip)
+
+        self.fake_client.driver.list_public_ip.\
+            assert_called_once_with()

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -34,7 +34,7 @@ class Client(BaseClient):
         return self.driver.start(instance_id)
 
     def reboot(self, instance_id):
-        pass
+        return self.driver.reboot(instance_id)
 
     def resize(self, instance_id, configuration):
         pass

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -25,7 +25,7 @@ class Client(BaseClient):
         return self.driver.list(**search_opts)
 
     def delete(self, instance_id):
-        pass
+        return self.driver.delete(instance_id)
 
     def shutdown(self, instance_id):
         pass

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -19,7 +19,7 @@ class Client(BaseClient):
                network_id, name, number, **kargs)
 
     def show(self, instance_id):
-        pass
+        return self.driver.show(instance_id)
 
     def list(self, **search_opts):
         pass

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -14,9 +14,9 @@ class Client(BaseClient):
                             provider, cloud_config)
 
     def create(self, image, flavor,
-               network_id, name, number, **kargs):
+               network_id, name, number, **kwargs):
         return self.driver.create(image, flavor,
-               network_id, name, number, **kargs)
+               network_id, name, number, **kwargs)
 
     def show(self, instance_id):
         return self.driver.show(instance_id)

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -12,3 +12,73 @@ class Client(BaseClient):
     def __init__(self, provider, cloud_config, *args, **kwargs):
         BaseClient.__init__(self, CONF.compute.driver_path,
                             provider, cloud_config)
+
+    def create(self, image, flavor,
+               network_id, name, number, **kargs):
+        return self.driver.create(image, flavor,
+               network_id, name, number, **kargs)
+
+    def show(self, instance_id):
+        pass
+
+    def list(self, **search_opts):
+        pass
+
+    def delete(self, instance_id):
+        pass
+
+    def shutdown(self, instance_id):
+        pass
+
+    def start(self, instance_id):
+        pass
+
+    def reboot(self, instance_id):
+        pass
+
+    def resize(self, instance_id, configuration):
+        pass
+
+    def add_sg(self, instance_id, new_sg):
+        """Add a security group"""
+        pass
+
+    def delete_sg(self, instance_id, new_sg):
+        """Delete a security group"""
+        pass
+
+    def list_sg(self, instance_id):
+        """List all security group"""
+        pass
+
+    def add_nic(self, instance_id, new_sg):
+        """Add a Network Interface Controller"""
+        pass
+
+    def delete_nic(self, instance_id, new_sg):
+        """Delete a Network Interface Controller"""
+        pass
+
+    def list_nic(self, instance_id):
+        """List all Network Interface Controller"""
+        pass
+
+    def add_private_ip(self, instance_id, new_sg):
+        """Add private IP"""
+        pass
+
+    def delete_private_ip(self, instance_id, new_sg):
+        """Delete private IP"""
+        pass
+
+    def add_public_ip(self, instance_id, new_sg):
+        """Add a external IP"""
+        pass
+
+    def delete_public_ip(self, instance_id, new_sg):
+        """Delete a external IP"""
+        pass
+
+    def list_ip(self, instance_id, new_sg):
+        """Add all IPs"""
+        pass

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -22,7 +22,7 @@ class Client(BaseClient):
         return self.driver.show(instance_id)
 
     def list(self, **search_opts):
-        pass
+        return self.driver.list(**search_opts)
 
     def delete(self, instance_id):
         pass

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -31,7 +31,7 @@ class Client(BaseClient):
         return self.driver.shutdown(instance_id)
 
     def start(self, instance_id):
-        pass
+        return self.driver.start(instance_id)
 
     def reboot(self, instance_id):
         pass

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -57,11 +57,11 @@ class Client(BaseClient):
         """List all security group"""
         pass
 
-    def add_nic(self, instance_id, new_sg):
+    def add_nic(self, instance_id, net_id):
         """Add a Network Interface Controller"""
-        pass
+        return self.driver.add_nic(instance_id, net_id)
 
-    def delete_nic(self, instance_id, new_sg):
+    def delete_nic(self, instance_id, net_id):
         """Delete a Network Interface Controller"""
         pass
 

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -73,7 +73,7 @@ class Client(BaseClient):
 
     def list_nic(self, instance_id):
         """List all Network Interface Controller"""
-        pass
+        return self.driver.list_nic(instance_id)
 
     def add_private_ip(self, instance_id, new_sg):
         """Add private IP"""

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -28,7 +28,7 @@ class Client(BaseClient):
         return self.driver.delete(instance_id)
 
     def shutdown(self, instance_id):
-        pass
+        return self.driver.shutdown(instance_id)
 
     def start(self, instance_id):
         pass

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -61,9 +61,15 @@ class Client(BaseClient):
         """Add a Network Interface Controller"""
         return self.driver.add_nic(instance_id, net_id)
 
-    def delete_nic(self, instance_id, net_id):
-        """Delete a Network Interface Controller"""
-        pass
+    def delete_nic(self, instance_id, attachment_id):
+        """Delete a Network Interface Controller
+
+        In OpenStack
+        :param instance_id:
+        :param attachment_id: port_id
+        :return:
+        """
+        return self.driver.delete_nic(instance_id, attachment_id)
 
     def list_nic(self, instance_id):
         """List all Network Interface Controller"""

--- a/calplus/v1/compute/client.py
+++ b/calplus/v1/compute/client.py
@@ -37,7 +37,13 @@ class Client(BaseClient):
         return self.driver.reboot(instance_id)
 
     def resize(self, instance_id, configuration):
-        pass
+        """
+        In OpenStack
+        :param instance_id:
+        :param configuration: flavor_id
+        :return:
+        """
+        self.driver.resize(instance_id, configuration)
 
     def add_sg(self, instance_id, new_sg):
         """Add a security group"""

--- a/calplus/v1/compute/drivers/base.py
+++ b/calplus/v1/compute/drivers/base.py
@@ -112,6 +112,7 @@ class BaseQuota(object):
         """Get quota from Cloud Provider."""
 
         # get all network quota from Cloud Provider.
+        #TODO: We need to improve this by survey for compute quota
         attrs = ("vcpus",
                  "instances",
                  "ram")

--- a/calplus/v1/compute/drivers/base.py
+++ b/calplus/v1/compute/drivers/base.py
@@ -88,7 +88,7 @@ class BaseDriver(object):
 
     @abc.abstractmethod
     def add_public_ip(self, instance_id, new_sg):
-        """Add a external IP"""
+        """Add an external IP"""
         pass
 
     @abc.abstractmethod

--- a/calplus/v1/compute/drivers/base.py
+++ b/calplus/v1/compute/drivers/base.py
@@ -1,9 +1,135 @@
+""" this is contain Abstract Class and Quota Class
+    for all network driver which we want to implement.
+"""
+
 import abc
 import six
 
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseDriver(object):
+    """abstract class for compute driver"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self):
+        super(BaseDriver, self).__init__()
+
+    @abc.abstractmethod
+    def create(self, image, flavor,
+               network_id, name, number, **kargs):
+        pass
+
+    @abc.abstractmethod
+    def show(self, instance_id):
+        pass
+
+    @abc.abstractmethod
+    def list(self, **search_opts):
+        pass
+
+    @abc.abstractmethod
+    def delete(self, instance_id):
+        pass
+
+    @abc.abstractmethod
+    def shutdown(self, instance_id):
+        pass
+
+    @abc.abstractmethod
+    def start(self, instance_id):
+        pass
+
+    @abc.abstractmethod
+    def reboot(self, instance_id):
+        pass
+
+    @abc.abstractmethod
+    def resize(self, instance_id, configuration):
+        pass
+
+    @abc.abstractmethod
+    def add_sg(self, instance_id, new_sg):
+        """Add a security group"""
+        pass
+
+    @abc.abstractmethod
+    def delete_sg(self, instance_id, new_sg):
+        """Delete a security group"""
+        pass
+
+    @abc.abstractmethod
+    def list_sg(self, instance_id):
+        """List all security group"""
+        pass
+
+    @abc.abstractmethod
+    def add_nic(self, instance_id, new_sg):
+        """Add a Network Interface Controller"""
+        pass
+
+    @abc.abstractmethod
+    def delete_nic(self, instance_id, new_sg):
+        """Delete a Network Interface Controller"""
+        pass
+
+    @abc.abstractmethod
+    def list_nic(self, instance_id):
+        """List all Network Interface Controller"""
+        pass
+
+    @abc.abstractmethod
+    def add_private_ip(self, instance_id, new_sg):
+        """Add private IP"""
+        pass
+
+    @abc.abstractmethod
+    def delete_private_ip(self, instance_id, new_sg):
+        """Delete private IP"""
+        pass
+
+    @abc.abstractmethod
+    def add_public_ip(self, instance_id, new_sg):
+        """Add a external IP"""
+        pass
+
+    @abc.abstractmethod
+    def delete_public_ip(self, instance_id, new_sg):
+        """Delete a external IP"""
+        pass
+
+    @abc.abstractmethod
+    def list_ip(self, instance_id, new_sg):
+        """Add all IPs"""
+        pass
+
+
+class BaseQuota(object):
+    """docstring for QuotaNetwork"""
+
+    def __init__(self):
+        super(BaseQuota, self).__init__()
+
+    def get(self):
+        """Get quota from Cloud Provider."""
+
+        # get all network quota from Cloud Provider.
+        attrs = ("vcpus",
+                 "instances",
+                 "ram")
+
+        for attr in attrs:
+            setattr(self, attr, eval("self.get_{}()".format(attr)))
+
+    def set(self, attr, value):
+        """Update quota for Network."""
+
+        # set special attribute.
+        setattr(self, attr, value)
+
+    def get_vcpus(self):
+        pass
+
+    def get_instances(self):
+        pass
+
+    def get_ram(self):
         pass

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -65,7 +65,8 @@ class OpenstackDriver(BaseDriver):
         return server
 
     def list(self, **search_opts):
-        pass
+        servers = self.client.servers.list()
+        return servers
 
     def delete(self, instance_id):
         pass

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -59,7 +59,10 @@ class OpenstackDriver(BaseDriver):
         return server
 
     def show(self, instance_id):
-        pass
+        server = self.client.servers.get(
+            instance_id
+        )
+        return server
 
     def list(self, **search_opts):
         pass

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -104,6 +104,7 @@ class OpenstackDriver(BaseDriver):
 
     def add_nic(self, instance_id, net_id):
         """Add a Network Interface Controller"""
+        #TODO: upgrade with port_id and fixed_ip in future
         self.client.servers.interface_attach(
             instance_id, None, net_id, None)
         return True

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -69,12 +69,12 @@ class OpenstackDriver(BaseDriver):
         return servers
 
     def delete(self, instance_id):
-        """If delete successfully, return () """
         self.client.servers.delete(instance_id)
         return True
 
     def shutdown(self, instance_id):
-        pass
+        self.client.servers.stop(instance_id)
+        return True
 
     def start(self, instance_id):
         pass

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -102,9 +102,11 @@ class OpenstackDriver(BaseDriver):
         """List all security group"""
         pass
 
-    def add_nic(self, instance_id, new_sg):
+    def add_nic(self, instance_id, net_id):
         """Add a Network Interface Controller"""
-        pass
+        self.client.servers.interface_attach(
+            instance_id, None, net_id, None)
+        return True
 
     def delete_nic(self, instance_id, new_sg):
         """Delete a Network Interface Controller"""

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -85,8 +85,10 @@ class OpenstackDriver(BaseDriver):
         self.client.servers.reboot(instance_id)
         return True
 
-    def resize(self, instance_id, configuration):
-        pass
+    def resize(self, instance_id, flavor_id):
+        self.client.servers.resize(instance_id, flavor_id)
+        self.client.servers.confirm_resize(instance_id)
+        return True
 
     def add_sg(self, instance_id, new_sg):
         """Add a security group"""

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -1,0 +1,146 @@
+""" OpenstackDriver for Compute
+    based on BaseDriver
+"""
+
+
+from datetime import datetime
+
+from keystoneauth1.identity import v3
+from keystoneauth1 import session
+from novaclient.client import Client
+
+from calplus.v1.compute.drivers.base import BaseDriver, BaseQuota
+
+
+PROVIDER = "OPENSTACK"
+
+
+class OpenstackDriver(BaseDriver):
+    """docstring for OpenstackDriver"""
+
+    def __init__(self, cloud_config):
+        super(OpenstackDriver, self).__init__()
+        self.auth_url = cloud_config['os_auth_url']
+        self.project_name = cloud_config['os_project_name']
+        self.username = cloud_config['os_username']
+        self.password = cloud_config['os_password']
+        self.user_domain_name = \
+            cloud_config.get('os_project_domain_name', 'default')
+        self.project_domain_name = \
+            cloud_config.get('os_user_domain_name', 'default')
+        self.driver_name = \
+            cloud_config.get('driver_name', 'default')
+        self.tenant_id = cloud_config.get('tenant_id', None)
+        self.limit = cloud_config.get('limit', None)
+        self._setup()
+
+    def _setup(self):
+        auth = v3.Password(auth_url=self.auth_url,
+                           user_domain_name=self.user_domain_name,
+                           username=self.username,
+                           password=self.password,
+                           project_domain_name=self.project_domain_name,
+                           project_name=self.project_name)
+        sess = session.Session(auth=auth)
+        self.client = Client("2.1", session=sess)
+        self.quota = OpenstackQuota(
+            self.client, self.tenant_id, self.limit)
+
+    def create(self, image_id, flavor_id,
+               network_id, name=None, number=1, **kargs):
+        if name is None:
+            name = unicode(datetime.now())
+        server = self.client.servers.create(
+            name=name,
+            image=image_id,
+            flavor=flavor_id,
+            nics=[{'net-id': network_id}]
+        )
+        return server
+
+    def show(self, instance_id):
+        pass
+
+    def list(self, **search_opts):
+        pass
+
+    def delete(self, instance_id):
+        pass
+
+    def shutdown(self, instance_id):
+        pass
+
+    def start(self, instance_id):
+        pass
+
+    def reboot(self, instance_id):
+        pass
+
+    def resize(self, instance_id, configuration):
+        pass
+
+    def add_sg(self, instance_id, new_sg):
+        """Add a security group"""
+        pass
+
+    def delete_sg(self, instance_id, new_sg):
+        """Delete a security group"""
+        pass
+
+    def list_sg(self, instance_id):
+        """List all security group"""
+        pass
+
+    def add_nic(self, instance_id, new_sg):
+        """Add a Network Interface Controller"""
+        pass
+
+    def delete_nic(self, instance_id, new_sg):
+        """Delete a Network Interface Controller"""
+        pass
+
+    def list_nic(self, instance_id):
+        """List all Network Interface Controller"""
+        pass
+
+    def add_private_ip(self, instance_id, new_sg):
+        """Add private IP"""
+        pass
+
+    def delete_private_ip(self, instance_id, new_sg):
+        """Delete private IP"""
+        pass
+
+    def add_public_ip(self, instance_id, new_sg):
+        """Add a external IP"""
+        pass
+
+    def delete_public_ip(self, instance_id, new_sg):
+        """Delete a external IP"""
+        pass
+
+    def list_ip(self, instance_id, new_sg):
+        """Add all IPs"""
+        pass
+
+
+class OpenstackQuota(BaseQuota):
+    """docstring for OpenStack Compute Quota"""
+    def __init__(self, client, tenant_id=None, limit=None):
+        super(OpenstackQuota, self).__init__()
+        self.client = client
+        self.tenant_id = tenant_id
+        self.limit = limit
+        self._setup()
+
+    def _setup(self):
+        pass
+
+    def get_vcpus(self):
+        pass
+
+    def get_instances(self):
+        pass
+
+    def get_ram(self):
+        pass

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -4,6 +4,7 @@
 
 
 from datetime import datetime
+import six
 
 from keystoneauth1.identity import v3
 from keystoneauth1 import session
@@ -49,7 +50,7 @@ class OpenstackDriver(BaseDriver):
     def create(self, image_id, flavor_id,
                network_id, name=None, number=1, **kargs):
         if name is None:
-            name = unicode(datetime.now())
+            name = six.text_type(datetime.now())
         server = self.client.servers.create(
             name=name,
             image=image_id,

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -115,8 +115,11 @@ class OpenstackDriver(BaseDriver):
         return True
 
     def list_nic(self, instance_id):
-        """List all Network Interface Controller"""
-        pass
+        """List all Network Interface Controller
+        """
+        #NOTE: interfaces a list of novaclient.v2.servers.Server
+        interfaces = self.client.servers.interface_list(instance_id)
+        return interfaces
 
     def add_private_ip(self, instance_id, new_sg):
         """Add private IP"""

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -81,7 +81,9 @@ class OpenstackDriver(BaseDriver):
         return True
 
     def reboot(self, instance_id):
-        pass
+        """Soft reboot"""
+        self.client.servers.reboot(instance_id)
+        return True
 
     def resize(self, instance_id, configuration):
         pass

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -109,9 +109,10 @@ class OpenstackDriver(BaseDriver):
             instance_id, None, net_id, None)
         return True
 
-    def delete_nic(self, instance_id, new_sg):
+    def delete_nic(self, instance_id, port_id):
         """Delete a Network Interface Controller"""
-        pass
+        self.client.servers.interface_detach(instance_id, port_id)
+        return True
 
     def list_nic(self, instance_id):
         """List all Network Interface Controller"""

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -33,6 +33,8 @@ class OpenstackDriver(BaseDriver):
             cloud_config.get('driver_name', 'default')
         self.tenant_id = cloud_config.get('tenant_id', None)
         self.limit = cloud_config.get('limit', None)
+        self.client_version = \
+            cloud_config.get('os_novaclient_version', '2.1')
         self._setup()
 
     def _setup(self):
@@ -43,7 +45,7 @@ class OpenstackDriver(BaseDriver):
                            project_domain_name=self.project_domain_name,
                            project_name=self.project_name)
         sess = session.Session(auth=auth)
-        self.client = Client("2.1", session=sess)
+        self.client = Client(self.client_version, session=sess)
         self.quota = OpenstackQuota(
             self.client, self.tenant_id, self.limit)
 

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -88,7 +88,11 @@ class OpenstackDriver(BaseDriver):
 
     def resize(self, instance_id, flavor_id):
         self.client.servers.resize(instance_id, flavor_id)
-        self.client.servers.confirm_resize(instance_id)
+        try:
+            self.client.servers.confirm_resize(instance_id)
+        except:
+            self.client.servers.revert_resize(instance_id)
+            return False
         return True
 
     def add_sg(self, instance_id, new_sg):

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -77,7 +77,8 @@ class OpenstackDriver(BaseDriver):
         return True
 
     def start(self, instance_id):
-        pass
+        self.client.servers.start(instance_id)
+        return True
 
     def reboot(self, instance_id):
         pass

--- a/calplus/v1/compute/drivers/openstack.py
+++ b/calplus/v1/compute/drivers/openstack.py
@@ -69,7 +69,9 @@ class OpenstackDriver(BaseDriver):
         return servers
 
     def delete(self, instance_id):
-        pass
+        """If delete successfully, return () """
+        self.client.servers.delete(instance_id)
+        return True
 
     def shutdown(self, instance_id):
         pass

--- a/calplus/v1/network/client.py
+++ b/calplus/v1/network/client.py
@@ -58,3 +58,6 @@ class Client(BaseClient):
          False: can't get new IP by quota or commitment
         """
         return self.driver.allocate_public_ip()
+
+    def list_public_ip(self, **search_opts):
+        return self.driver.list_public_ip(**search_opts)

--- a/calplus/v1/network/client.py
+++ b/calplus/v1/network/client.py
@@ -51,4 +51,10 @@ class Client(BaseClient):
         return self.driver.disconnect_external_net(network_id)
 
     def allocate_public_ip(self):
+        """
+
+        :return:
+         True : got new Public IP
+         False: can't get new IP by quota or commitment
+        """
         return self.driver.allocate_public_ip()

--- a/calplus/v1/network/client.py
+++ b/calplus/v1/network/client.py
@@ -43,3 +43,12 @@ class Client(BaseClient):
 
     def update(self, network_id, network):
         return self.driver.update(network_id, network)
+
+    def connect_external_net(self, network_id):
+        return self.driver.connect_external_net(network_id)
+
+    def disconnect_external_net(self, network_id):
+        return self.driver.disconnect_external_net(network_id)
+
+    def allocate_public_ip(self, network_id):
+        return self.driver.allocate_public_ip(network_id)

--- a/calplus/v1/network/client.py
+++ b/calplus/v1/network/client.py
@@ -50,5 +50,5 @@ class Client(BaseClient):
     def disconnect_external_net(self, network_id):
         return self.driver.disconnect_external_net(network_id)
 
-    def allocate_public_ip(self, network_id):
-        return self.driver.allocate_public_ip(network_id)
+    def allocate_public_ip(self):
+        return self.driver.allocate_public_ip()

--- a/calplus/v1/network/drivers/amazon.py
+++ b/calplus/v1/network/drivers/amazon.py
@@ -122,6 +122,10 @@ class AmazonDriver(BaseDriver):
     def disconnect_external_net(self, network_id):
         pass
 
+    def allocate_public_ip(self):
+        self.client.allocate_address(Domain='vpc')
+        return True
+
 
 class AmazonQuota(BaseQuota):
 

--- a/calplus/v1/network/drivers/amazon.py
+++ b/calplus/v1/network/drivers/amazon.py
@@ -128,7 +128,7 @@ class AmazonQuota(BaseQuota):
     """docstring for AmazonQuota"""
 
     def __init__(self, client, limit=None):
-        super(BaseQuota, self).__init__()
+        super(AmazonQuota, self).__init__()
         self.client = client
         self.limit = limit
         self._setup()

--- a/calplus/v1/network/drivers/amazon.py
+++ b/calplus/v1/network/drivers/amazon.py
@@ -126,6 +126,9 @@ class AmazonDriver(BaseDriver):
         self.client.allocate_address(Domain='vpc')
         return True
 
+    def list_public_ip(self, **search_opts):
+        pass
+
 
 class AmazonQuota(BaseQuota):
 

--- a/calplus/v1/network/drivers/amazon.py
+++ b/calplus/v1/network/drivers/amazon.py
@@ -122,6 +122,7 @@ class AmazonDriver(BaseDriver):
     def disconnect_external_net(self, network_id):
         pass
 
+
 class AmazonQuota(BaseQuota):
 
     """docstring for AmazonQuota"""

--- a/calplus/v1/network/drivers/amazon.py
+++ b/calplus/v1/network/drivers/amazon.py
@@ -116,6 +116,11 @@ class AmazonDriver(BaseDriver):
         # 3 : delete vpc
         return self.client.delete_vpc(VpcId=vpc_id)
 
+    def connect_external_net(self, network_id):
+        pass
+
+    def disconnect_external_net(self, network_id):
+        pass
 
 class AmazonQuota(BaseQuota):
 

--- a/calplus/v1/network/drivers/base.py
+++ b/calplus/v1/network/drivers/base.py
@@ -43,6 +43,10 @@ class BaseDriver(object):
     def disconnect_external_net(self, network_id):
         pass
 
+    @abc.abstractmethod
+    def allocate_public_ip(self, network_id):
+        pass
+
 
 class BaseQuota(object):
     """docstring for QuotaNetwork"""

--- a/calplus/v1/network/drivers/base.py
+++ b/calplus/v1/network/drivers/base.py
@@ -35,6 +35,14 @@ class BaseDriver(object):
     def update(self, network_id, network):
         pass
 
+    @abc.abstractmethod
+    def connect_external_net(self, network_id):
+        pass
+
+    @abc.abstractmethod
+    def disconnect_external_net(self, network_id):
+        pass
+
 
 class BaseQuota(object):
     """docstring for QuotaNetwork"""

--- a/calplus/v1/network/drivers/base.py
+++ b/calplus/v1/network/drivers/base.py
@@ -48,7 +48,6 @@ class BaseQuota(object):
     """docstring for QuotaNetwork"""
     def __init__(self):
         super(BaseQuota, self).__init__()
-        self.get()
 
     def get(self):
         """Get quota from Cloud Provider."""

--- a/calplus/v1/network/drivers/base.py
+++ b/calplus/v1/network/drivers/base.py
@@ -47,6 +47,10 @@ class BaseDriver(object):
     def allocate_public_ip(self, network_id):
         pass
 
+    @abc.abstractmethod
+    def list_public_ip(self, **search_opts):
+        pass
+
 
 class BaseQuota(object):
     """docstring for QuotaNetwork"""

--- a/calplus/v1/network/drivers/openstack.py
+++ b/calplus/v1/network/drivers/openstack.py
@@ -14,6 +14,7 @@ PROVIDER = "OPENSTACK"
 
 
 class OpenstackDriver(BaseDriver):
+
     """docstring for OpenstackDriver"""
 
     def __init__(self, cloud_config):
@@ -43,6 +44,22 @@ class OpenstackDriver(BaseDriver):
         self.client = client.Client(session=sess)
         self.network_quota = OpenstackQuota(
             self.client, self.tenant_id, self.limit)
+
+    def _check_external_network(self):
+        networks = self.client.list_networks().get('networks')
+        for network in networks:
+            external = network.get('provider:physical_network')
+            if external is not None:
+                return network.get('id')
+        return None
+
+    def _check_router_external_gateway(self):
+        routers = self.client.list_routers().get('routers')
+        for router in routers:
+            external = router.get('external_gateway_info')
+            if external is not None:
+                return router.get('id')
+        return None
 
     def create(self, name, cidr, **kargs):
         admin_state_up = kargs.pop('admin_state_up', True)
@@ -115,8 +132,32 @@ class OpenstackDriver(BaseDriver):
     def delete(self, network_id):
         return self.client.delete_network(network_id)
 
+    def connect_external_net(self, subnet_id):
+        router_id = self._check_router_external_gateway()
+        if router_id is None:
+            network_id = self._check_external_network()
+            if network_id is None:
+                raise Exception()
+            router = {
+                "name": "default",
+                "external_gateway_info": {
+                    "network_id": "{}".format(network_id)
+                }
+            }
+            router = self.create_router({'router': router})
+
+        body = {
+            "subnet_id": "{}".format(subnet_id)
+        }
+        return self.client.add_interface_router(router_id,body)
+
+    def disconnect_external_net(self, network_id):
+        #just detach all connect to router have external_gateway
+        pass
+
 
 class OpenstackQuota(BaseQuota):
+
     """docstring for OpenstackQuota"""
 
     def __init__(self, client, tenant_id=None, limit=None):

--- a/calplus/v1/network/drivers/openstack.py
+++ b/calplus/v1/network/drivers/openstack.py
@@ -155,6 +155,16 @@ class OpenstackDriver(BaseDriver):
         #just detach all connect to router have external_gateway
         pass
 
+    def allocate_public_ip(self):
+        external_net = self._check_external_network()
+        if external_net:
+            create_dict = {'floating_network_id': external_net,
+                           'tenant_id': self.network_quota.tenant_id}
+            self.client.create_floatingip({'floatingip': create_dict})
+        else:
+            return False
+        return True
+
 
 class OpenstackQuota(BaseQuota):
 

--- a/calplus/v1/network/drivers/openstack.py
+++ b/calplus/v1/network/drivers/openstack.py
@@ -165,6 +165,9 @@ class OpenstackDriver(BaseDriver):
             return False
         return True
 
+    def list_public_ip(self, **search_opts):
+        pass
+
 
 class OpenstackQuota(BaseQuota):
 

--- a/calplus/v1/network/drivers/openstack.py
+++ b/calplus/v1/network/drivers/openstack.py
@@ -149,7 +149,7 @@ class OpenstackDriver(BaseDriver):
         body = {
             "subnet_id": "{}".format(subnet_id)
         }
-        return self.client.add_interface_router(router_id,body)
+        return self.client.add_interface_router(router_id, body)
 
     def disconnect_external_net(self, network_id):
         #just detach all connect to router have external_gateway
@@ -161,7 +161,7 @@ class OpenstackQuota(BaseQuota):
     """docstring for OpenstackQuota"""
 
     def __init__(self, client, tenant_id=None, limit=None):
-        super(BaseQuota, self).__init__()
+        super(OpenstackQuota, self).__init__()
         self.client = client
         self.tenant_id = tenant_id
         self.limit = limit

--- a/etc/calplus/calplus-config-generator.conf
+++ b/etc/calplus/calplus-config-generator.conf
@@ -1,0 +1,5 @@
+[DEFAULT]
+wrap_width = 80
+output_file = etc/calplus/calplus.conf.sample
+namespace = calplus.conf
+namespace = oslo.log

--- a/etc/calplus/calplus.conf.sample
+++ b/etc/calplus/calplus.conf.sample
@@ -1,0 +1,210 @@
+[DEFAULT]
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# DEPRECATED: If set to false, the logging level will be set to WARNING instead
+# of the default INFO level. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#verbose = true
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, logging_context_format_string). (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and Linux
+# platform is used. This option is ignored if log_config_append is set. (boolean
+# value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_syslog = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = false
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message is
+# DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Interval, number of seconds, of log rate limiting. (integer value)
+#rate_limit_interval = 0
+
+# Maximum number of logged messages per rate_limit_interval. (integer value)
+#rate_limit_burst = 0
+
+# Log level name used by rate limiting: CRITICAL, ERROR, INFO, WARNING, DEBUG or
+# empty string. Logs with level greater or equal to rate_limit_except_level are
+# not filtered. An empty string means that all levels are filtered. (string
+# value)
+#rate_limit_except_level = CRITICAL
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+
+[amazon]
+
+#
+# From calplus.conf
+#
+
+# List of available Amazon Hosts (dict value)
+#hosts = aws1:{'region_name': 'RegionOne', 'aws_secret_access_key': 'd2246a2235ca40ffa7fbf817ae1108ba', 'limit': {'rbac_policy': -1, 'subnetpool': -1, 'security_group': 10, 'router': 10, 'port': 50, 'security_group_rule': 100, 'subnet': 10, 'vpc': 5, 'floatingip': 50}, 'endpoint_url': 'http://192.168.122.75:8788', 'aws_access_key_id': 'c543fa29eeaf4894a1078ec0860baefd'}
+
+
+[block_storage]
+
+#
+# From calplus.conf
+#
+
+# Default path to block storage drivers (string value)
+#driver_path = calplus.v1.block_storage.drivers
+
+
+[compute]
+
+#
+# From calplus.conf
+#
+
+# Default path to compute drivers (string value)
+#driver_path = calplus.v1.compute.drivers
+
+
+[network]
+
+#
+# From calplus.conf
+#
+
+# Default path to network drivers (string value)
+#driver_path = calplus.v1.network.drivers
+
+
+[object_storage]
+
+#
+# From calplus.conf
+#
+
+# Default path to object storage drivers (string value)
+#driver_path = calplus.v1.object_storage.drivers
+
+
+[openstack]
+
+#
+# From calplus.conf
+#
+
+# List of available OpenStack Hosts (dict value)
+#hosts = openstack1:{'os_project_name': 'admin', 'os_image_api_version': '2', 'os_novaclient_version': '2.1', 'os_identity_api_version': '3', 'tenant_id': 'fake_tenant_id', 'os_auth_url': 'http://host1:35357/v3', 'os_username': 'admin', 'limit': {'rbac_policy': -1, 'subnetpool': -1, 'security_group': 10, 'router': 10, 'port': 50, 'security_group_rule': 100, 'subnet': 10, 'floatingip': 50, 'network': 10}, 'os_password': 'ADMIN_PASS', 'os_project_domain_name': 'default', 'os_user_domain_name': 'default'},openstack2:{'os_password': 'ADMIN_PASS', 'os_identity_api_version': '3', 'os_project_name': 'admin', 'limit': {'rbac_policy': -1, 'subnetpool': -1, 'security_group': 10, 'router': 10, 'port': 50, 'security_group_rule': 100, 'subnet': 10, 'floatingip': 50, 'network': 10}, 'os_user_domain_name': 'default', 'os_project_domain_name': 'default', 'os_auth_url': 'http://host2:35357/v3', 'os_username': 'admin', 'os_image_api_version': '2', 'tenant_id': 'fake_tenant_id'}
+
+
+[providers]
+
+#
+# From calplus.conf
+#
+
+#
+#                             Dict with key is provider, and value is
+#                             Driver class.
+#                              (dict value)
+#driver_mapper = amazon:AmazonDriver,openstack:OpenstackDriver
+
+
+[wsgi]
+
+#
+# From calplus.conf
+#
+
+#
+# It represents a python format string that is used as the template to generate
+# log lines. The following values can be formatted into it: client_ip,
+# date_time, request_line, status_code, body_length, wall_seconds.
+# This option is used for building custom request loglines.
+# Possible values:
+#  * '%(client_ip)s "%(request_line)s" status: %(status_code)s'
+#    'len: %(body_length)s time: %(wall_seconds).7f' (default)
+#  * Any formatted string formed by specific values.
+#  (string value)
+# Deprecated group/name - [DEFAULT]/wsgi_log_format
+#wsgi_log_format = %(client_ip)s "%(request_line)s" status: %(status_code)s len: %(body_length)s time: %(wall_seconds).7f
+
+# Address on which the self-hosting server will listen (IP address value)
+#host = 0.0.0.0
+
+# Port on which the self-hosting server will listen. (port value)
+# Minimum value: 0
+# Maximum value: 65535
+#port = 8888

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gunicorn
 python-neutronclient
 keystoneauth1
 boto3
+python-novaclient

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,9 +93,10 @@ data_files = [('my_data', ['data/data_file'])]
 
 
 [entry_points]
-
 cal.v1.resource_extensions =
     basics = cal.v1.resource_extensions.basic:Basics
+oslo.config.opts =
+	calplus.conf = calplus.conf.opts:list_opts
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python

--- a/tox.ini
+++ b/tox.ini
@@ -67,3 +67,6 @@ commands =
 # H405 multi line docstring summary not separated with an empty line
 ignore = E125,E126,E128,E129,E265,H404,H405
 show-source = true
+
+[testenv:genconfig]
+commands = oslo-config-generator --config-file=etc/calplus/calplus-config-generator.conf


### PR DESCRIPTION
Init compute driver for OpenStack and upgrade network driver

Init OPS compute driver (Init base driver follow proposal):

- create
- show
- list
- delete
- shutdown
- start
- reboot
- resize
- add_nic
- delete_nic
- list_nic

Upgrade network driver
- allocate_public_ip